### PR TITLE
Add Outlook add-in time tracking example without binary assets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,19 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Chrome against localhost",
-      "type": "pwa-chrome",
+      "name": "Start Outlook Add-in",
+      "type": "pwa-edge",
       "request": "launch",
-      "url": "http://localhost:5500",
-      "webRoot": "${workspaceFolder}",
-      "preLaunchTask": "Start dev server"
+      "url": "http://localhost:5500/addin/taskpane.html",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "npm start",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/addin/taskpane.html
+++ b/addin/taskpane.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Category Time Tracker</title>
+</head>
+<body>
+  <h1>Category Time Tracker</h1>
+  <button id="showTime">Show Time</button>
+  <ul id="timeList"></ul>
+  <script src="taskpane.js"></script>
+</body>
+</html>

--- a/addin/taskpane.js
+++ b/addin/taskpane.js
@@ -1,0 +1,43 @@
+let startTime = null;
+
+Office.initialize = () => {
+  const item = Office.context.mailbox.item;
+  if (item) {
+    startTime = Date.now();
+    Office.context.mailbox.addHandlerAsync(Office.EventType.ItemChanged, onItemChanged);
+  }
+
+  document.getElementById('showTime').addEventListener('click', renderTime);
+};
+
+function onItemChanged() {
+  const end = Date.now();
+  saveTime(end - startTime);
+  startTime = Date.now();
+}
+
+function saveTime(duration) {
+  Office.context.mailbox.item.categories.getAsync(result => {
+    if (result.status === Office.AsyncResultStatus.Succeeded) {
+      result.value.forEach(cat => {
+        const key = `time_${cat}`;
+        const current = parseInt(localStorage.getItem(key) || '0', 10);
+        localStorage.setItem(key, current + duration);
+      });
+    }
+  });
+}
+
+function renderTime() {
+  const list = document.getElementById('timeList');
+  list.innerHTML = '';
+  Object.keys(localStorage)
+    .filter(k => k.startsWith('time_'))
+    .forEach(k => {
+      const li = document.createElement('li');
+      const cat = k.substring(5);
+      const ms = parseInt(localStorage.getItem(k), 10);
+      li.textContent = `${cat}: ${Math.round(ms / 60000)} min`;
+      list.appendChild(li);
+    });
+}

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="MailApp">
+  <Id>0f8fad5b-d9cb-469f-a165-70867728950e</Id>
+  <Version>1.0.0.0</Version>
+  <ProviderName>Example</ProviderName>
+  <DefaultLocale>en-US</DefaultLocale>
+  <DisplayName DefaultValue="Category Time Tracker"/>
+  <Description DefaultValue="Tracks time spent per Outlook category"/>
+  <IconUrl DefaultValue="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/B8AAwMB/6M4R9AAAAAASUVORK5CYII="/>
+  <SupportUrl DefaultValue="https://example.com"/>
+  <Hosts>
+    <Host Name="Mailbox"/>
+  </Hosts>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="http://localhost:5500/addin/taskpane.html"/>
+    <RequestedHeight>250</RequestedHeight>
+  </DefaultSettings>
+  <Permissions>ReadWriteMailbox</Permissions>
+  <Rule xsi:type="RuleCollection" Mode="Or">
+    <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read"/>
+    <Rule xsi:type="ItemIs" ItemType="Message" FormType="Edit"/>
+  </Rule>
+</OfficeApp>


### PR DESCRIPTION
## Summary
- add minimal Outlook add-in to track time per category
- configure VS Code launch for running and debugging the add-in
- embed add-in icon via data URI to avoid binary files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7126655c83249b4c1f1fde467366